### PR TITLE
People usually use 'Е' and 'е' where they should use  'Ё' and 'ё'

### DIFF
--- a/lightautoml/text/tokenizer.py
+++ b/lightautoml/text/tokenizer.py
@@ -222,6 +222,7 @@ class SimpleRuTokenizer(BaseTokenizer):
 
         """
         snt = snt.strip()
+        snt = snt.replace('Ё', 'Е').replace('ё', 'е')
         s = re.sub('[^A-Za-zА-Яа-я0-9]+', ' ', snt)
         s = re.sub(r'^\d+\s|\s\d+\s|\s\d+$', ' ', s)
         return s


### PR DESCRIPTION
1. Люди часто используют 'Е' и 'е' вместо 'Ё' и 'ё'
Поэтому проще сразу заменить их в тексте и тем самым повысить качество модели

2. В Unicode символы 'Ё' и 'ё' находятся вне диапазона 'А-Яа-я' и таким образом ломается препроцессинг в русском языке:
>>> import re
>>> re.sub('[^A-Za-zА-Яа-я0-9]+', ' ', 'вёсла')
'в сла'