### PR TITLE
Split to words but not space

### DIFF
--- a/lightautoml/text/tokenizer.py
+++ b/lightautoml/text/tokenizer.py
@@ -64,7 +64,7 @@ class BaseTokenizer:
             resulting list of tokens.
 
         """
-        return snt.split(' ')
+        return snt.split()
 
     def filter_tokens(self, snt: List[str]) -> List[str]:
         """Clean list of sentence tokens.
@@ -236,7 +236,7 @@ class SimpleRuTokenizer(BaseTokenizer):
             resulting list of tokens.
 
         """
-        return snt.split(' ')
+        return snt.split()
 
     def filter_tokens(self, snt: List[str]) -> List[str]:
         """Clean list of sentence tokens.
@@ -349,7 +349,7 @@ class SimpleEnTokenizer(BaseTokenizer):
             resulting list of tokens.
 
         """
-        return snt.split(' ')
+        return snt.split()
 
     def filter_tokens(self, snt: List[str]) -> List[str]:
         """Clean list of sentence tokens.


### PR DESCRIPTION
При ручном наборе часто в тексте встречаются двойные пробелы, что не учитывается в токенизации.
Также при распознавании текста, выровненного по ширине, в некоторых случаях между словами вставляются цепочки пробельных символов.

В таком случае вызов метода split без параметров поделит текст на слова с использованием последовательности пробелов как единичного пробела:
>>> 'you  are   here'.split(' ')
['you', '', 'are', '', '', 'here']
>>> 'you  are   here'.split()
['you', 'are', 'here']